### PR TITLE
Deploy application and check backend service

### DIFF
--- a/backend/config/database.js
+++ b/backend/config/database.js
@@ -1,6 +1,16 @@
 const { Pool } = require('pg');
 require('dotenv').config();
 
+// Allow automatic construction of DATABASE_URL from individual PG* env vars (useful for Netlify-Neon integration)
+if (!process.env.DATABASE_URL && process.env.PGHOST && process.env.PGUSER) {
+  const user = encodeURIComponent(process.env.PGUSER);
+  const password = encodeURIComponent(process.env.PGPASSWORD || '');
+  const host = process.env.PGHOST;
+  const port = process.env.PGPORT || '5432';
+  const db = process.env.PGDATABASE || process.env.PGUSER;
+  process.env.DATABASE_URL = `postgres://${user}:${password}@${host}:${port}/${db}`;
+}
+
 
 // Determine when to enforce SSL. Neon PostgreSQL always requires SSL even from local environments.
 // 1) Any DATABASE_URL that points to *.neon.tech

--- a/backend/index.js
+++ b/backend/index.js
@@ -468,5 +468,14 @@ const startServer = async () => {
   }
 };
 
-// Start the server
-startServer();
+// Detect Netlify Functions environment
+if (process.env.NETLIFY) {
+  // Initialize database once for function cold start
+  initializeDatabase();
+
+  // Export the Express app for serverless handler
+  module.exports = app;
+} else if (require.main === module) {
+  // Start the server normally when executed directly (local dev)
+  startServer();
+}

--- a/netlify.toml
+++ b/netlify.toml
@@ -4,7 +4,7 @@
   # Directory with the static site output (for Vite this is usually `dist`)
   publish  = "dist"
   # Source folder for Netlify Functions (uncomment if you convert the backend to serverless functions)
-  # functions = "netlify/functions"
+  functions = "netlify/functions"
 
 #───────────────
 # API Routing
@@ -16,19 +16,19 @@
 # Uncomment the block that matches your deployment strategy and delete the other.
 
 # --- Option 1: External backend (default) ---
-[[redirects]]
-  from = "/api/*"
-  # REPLACE `https://your-backend.example.com` with the live backend base URL
-  to   = "https://your-backend.example.com/api/:splat"
-  status = 200  # proxy
-  force  = true
+# [[redirects]]
+#   from = "/api/*"
+#   # REPLACE `https://your-backend.example.com` with the live backend base URL
+#   to   = "https://your-backend.example.com/api/:splat"
+#   status = 200  # proxy
+#   force  = true
 
 # --- Option 2: Backend inside Netlify Functions ---
-# [[redirects]]
-#   from   = "/api/*"
-#   to     = "/.netlify/functions/server/:splat"
-#   status = 200
-#   force  = true
+[[redirects]]
+  from   = "/api/*"
+  to     = "/.netlify/functions/server/:splat"
+  status = 200
+  force  = true
 
 #───────────────
 # Environment variables

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,40 @@
+[build]
+  # Front-end build command
+  command = "npm run build"
+  # Directory with the static site output (for Vite this is usually `dist`)
+  publish  = "dist"
+  # Source folder for Netlify Functions (uncomment if you convert the backend to serverless functions)
+  # functions = "netlify/functions"
+
+#───────────────
+# API Routing
+#───────────────
+# There are two common ways to make the CineMatch backend reachable:
+#   1) Proxy requests to an externally-hosted backend service
+#   2) Run the backend as a Netlify Function (e.g. `/.netlify/functions/server`)
+#
+# Uncomment the block that matches your deployment strategy and delete the other.
+
+# --- Option 1: External backend (default) ---
+[[redirects]]
+  from = "/api/*"
+  # REPLACE `https://your-backend.example.com` with the live backend base URL
+  to   = "https://your-backend.example.com/api/:splat"
+  status = 200  # proxy
+  force  = true
+
+# --- Option 2: Backend inside Netlify Functions ---
+# [[redirects]]
+#   from   = "/api/*"
+#   to     = "/.netlify/functions/server/:splat"
+#   status = 200
+#   force  = true
+
+#───────────────
+# Environment variables
+#───────────────
+# Ensure the front-end code points to the same base path (`/api`) at build time.
+[context.production.environment]
+  VITE_API_BASE_URL = "/api"
+
+# You can also define BACKEND_DB_URL, JWT_SECRET, etc. here if your Netlify Functions need them.

--- a/netlify/functions/server.cjs
+++ b/netlify/functions/server.cjs
@@ -1,0 +1,6 @@
+const serverless = require('serverless-http');
+
+// Import the Express application
+const expressApp = require('../../backend/index.js');
+
+module.exports.handler = serverless(expressApp);

--- a/package.json
+++ b/package.json
@@ -20,7 +20,22 @@
     "react-dom": "^18.2.0",
     "react-i18next": "^15.6.0",
     "react-router-dom": "^7.6.3",
-    "recharts": "^2.10.1"
+    "recharts": "^2.10.1",
+    "express": "^5.1.0",
+    "cors": "^2.8.5",
+    "compression": "^1.7.4",
+    "helmet": "^7.1.0",
+    "dotenv": "^16.3.1",
+    "pg": "^8.11.3",
+    "ioredis": "^5.3.2",
+    "bull": "^4.12.2",
+    "joi": "^17.11.0",
+    "bcryptjs": "^2.4.3",
+    "jsonwebtoken": "^9.0.2",
+    "express-rate-limit": "^7.1.5",
+    "express-validator": "^7.0.1",
+    "uuid": "^9.0.1",
+    "serverless-http": "^3.2.0"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^6.6.3",

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -1,0 +1,11 @@
+interface ImportMetaEnv {
+  readonly VITE_API_BASE_URL?: string;
+  // Add more custom env vars here...
+  [key: string]: any;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}
+
+// Make sure this file is included in the compilation by matching the tsconfig include patterns.

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -1,5 +1,5 @@
 // API Service for backend communication
-const API_BASE_URL = 'http://localhost:4000/api';
+const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || '/api';
 
 export interface User {
   id: string;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -33,7 +33,8 @@
       "@/services/*": ["src/services/*"],
       "@/hooks/*": ["src/hooks/*"],
       "@/types/*": ["src/types/*"]
-    }
+    },
+    "types": ["vite/client"]
   },
   "include": [
     "src/**/*.ts",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -33,8 +33,7 @@
       "@/services/*": ["src/services/*"],
       "@/hooks/*": ["src/hooks/*"],
       "@/types/*": ["src/types/*"]
-    },
-    "types": ["vite/client"]
+    }
   },
   "include": [
     "src/**/*.ts",


### PR DESCRIPTION
Enable full-stack deployment on Netlify by converting the Express backend to a serverless function, with TypeScript and Neon DB fixes.

Netlify does not natively run long-lived Node.js servers, so the Express backend was converted to a Netlify Function using `serverless-http`. This PR also addresses TypeScript errors related to `import.meta.env` by adding explicit type declarations and ensures the database connection is compatible with Netlify's Neon Postgres integration by constructing `DATABASE_URL` from individual `PG*` environment variables.